### PR TITLE
Migrate to PHP 7.2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,11 @@ virtualization/
 solr/
 var/
 .env*
+ansible.cfg
+.php*
+Vagrantfile
+docs/
+docker-compose*
+.git*
+.travis.yml
+Dockerfile

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Autodetect text files
+* text=auto
+
+*.png binary
+
+# Force the following filetypes to have unix eols, so Windows does not break them
+*.html text eol=lf
+*.php text eol=lf
+*.js text eol=lf
+*.css text eol=lf
+*.less text eol=lf
+
+*.sh text eol=lf

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,8 +38,9 @@ branch_release:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - docker build -t $CI_REGISTRY_IMAGE:${IMAGE_TAG} .
     - docker push $CI_REGISTRY_IMAGE:${IMAGE_TAG}
+    - docker rmi $CI_REGISTRY_IMAGE:${IMAGE_TAG}
   tags:
-    - dind
+    - shell
   except:
     - tags
   when: manual
@@ -54,7 +55,7 @@ tagged_release:
     - docker push $CONTAINER_RELEASE_IMAGE_BASE:${CI_COMMIT_REF_NAME#v}
     - docker push "$CONTAINER_RELEASE_IMAGE_BASE:latest"
   tags:
-    - dind
+    - shell
   only:
     - tags
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,6 @@ php-coding-and-tests:
   stage: test
   script:
     - php -v && composer --version
-    - mv /usr/local/etc/php/conf.d/docker-php-ext-xdebug.{ini,disabled}
     - composer install --prefer-dist --no-ansi --no-interaction --no-progress --optimize-autoloader
     - scripts/run_phpcs.sh
     - bin/console > /dev/null

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
 stages:
-  - php-cs
   - test
   - build
   - release
@@ -18,18 +17,14 @@ before_script:
   - export CLEANED_CI_COMMIT_REF_NAME="${CI_COMMIT_REF_NAME#v}"
   - export COMPOSER_CACHE_DIR=`pwd`/.composer-cache
 
-.need_composer: &need_composer
-  before_script:
-    - php -v && composer --version
-    - composer install --prefer-dist --no-interaction --optimize-autoloader
-
 ##### Jobs
-php-coding-and-tests:7.1:
-  image: docker.klink.asia/main/docker-php:7.1
-  <<: *need_composer
-  stage: php-cs
+php-coding-and-tests:
+  image: edbizarro/gitlab-ci-pipeline-php:7.2
+  stage: test
   script:
+    - php -v && composer --version
     - mv /usr/local/etc/php/conf.d/docker-php-ext-xdebug.{ini,disabled}
+    - composer install --prefer-dist --no-ansi --no-interaction --no-progress --optimize-autoloader
     - scripts/run_phpcs.sh
     - bin/console > /dev/null
     - scripts/run_test_migrations.sh
@@ -104,7 +99,7 @@ canary_juliet_deploy:
 
 canary_try_deploy:
   <<: *canary_deploy
-  environment: "Staging on try"
+  environment: "Staging"
   variables:
     DEPLOY_FOLDER: $STAGING_T_FOLDER
     DEPLOY_IMAGE: $STAGING_T_IMAGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
+  - 7.3
 
 branches:
   only:
@@ -13,7 +13,7 @@ branches:
 
 matrix:
   allow_failures:
-    - php: 7.2
+    - php: 7.3
 
 sudo: required
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-CONSOLE="bin/console"
+
+CONSOLE="php bin/console"
 CONFIG_FILE=".env"
 
 rm -fr var/cache/*

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -11,4 +11,4 @@ ${CONSOLE} doctrine:migrations:migrate --no-interaction
 chown www-data:www-data --recursive ./var
 
 # Start Supervisor daemon
-exec /usr/bin/supervisord
+exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
- Use PHP 7.2 as the base image
- Switch to test on PHP 7.2 (and 7.3 on Travis CI)
- Use a multistep approach to build the Docker image (removes composer dependency from production image)
- Optimize docker build process to remove unneeded files